### PR TITLE
fix: projectId now defined

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -9,8 +9,9 @@ import { Forma } from "forma-embedded-view-sdk/auto";
  * @returns {string}
  */
 export async function createElementFromGlb(name, glbContents) {
+  const projectId = Forma.getProjectId();
   const { fileId } = await Forma.integrateElements.uploadFile({
-    authcontext: Forma.getProjectId(),
+    authcontext: projectId,
     data: glbContents,
   });
 


### PR DESCRIPTION
This example failed on line 48 of sdk.js before this fix, as projectId was not defined.

With this fix I properly got my local glb into library again.